### PR TITLE
fixed some typos

### DIFF
--- a/modules/databases.adoc
+++ b/modules/databases.adoc
@@ -251,7 +251,7 @@ labels. `describe` the `nationalparks` service:
 ----
 oc describe service nationalparks
 Name:                   nationalparks
-Namespace:              explore-00
+Namespace:              explore-user00
 Labels:                 app=nationalparks
 Selector:               deploymentconfig=nationalparks
 Type:                   ClusterIP

--- a/modules/databases.adoc
+++ b/modules/databases.adoc
@@ -251,7 +251,7 @@ labels. `describe` the `nationalparks` service:
 ----
 oc describe service nationalparks
 Name:                   nationalparks
-Namespace:              explore-user00
+Namespace:              explore{{USER_SUFFIX}}
 Labels:                 app=nationalparks
 Selector:               deploymentconfig=nationalparks
 Type:                   ClusterIP

--- a/modules/docker.adoc
+++ b/modules/docker.adoc
@@ -129,7 +129,7 @@ kind: Pod
 metadata:
   annotations:
     kubernetes.io/created-by: |
-      {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"explore-user00","name":"parksmap-1","uid":"b5ae65e9-897e-11e6-bdaa-2cc2602f8794","apiVersion":"v1","resourceVersion":"6924"}}
+      {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"explore{{USER_SUFFIX}}","name":"parksmap-1","uid":"b5ae65e9-897e-11e6-bdaa-2cc2602f8794","apiVersion":"v1","resourceVersion":"6924"}}
     openshift.io/deployment-config.latest-version: "1"
     openshift.io/deployment-config.name: parksmap
     openshift.io/deployment.name: parksmap-1
@@ -237,9 +237,9 @@ metadata:
   labels:
     app: parksmap
   name: parksmap
-  namespace: explore-user00
+  namespace: explore{{USER_SUFFIX}}
   resourceVersion: "6893"
-  selfLink: /api/v1/namespaces/explore-user00/services/parksmap
+  selfLink: /api/v1/namespaces/explore{{USER_SUFFIX}}/services/parksmap
   uid: b51260a9-897e-11e6-bdaa-2cc2602f8794
 spec:
   clusterIP: 172.30.169.213
@@ -312,7 +312,7 @@ You should see something like the following output:
 [source]
 ----
 Name:                   parksmap
-Namespace:              explore-user00
+Namespace:              explore{{USER_SUFFIX}}
 Labels:                 app=parksmap
 Selector:               deploymentconfig=parksmap
 Type:                   ClusterIP

--- a/modules/docker.adoc
+++ b/modules/docker.adoc
@@ -129,7 +129,7 @@ kind: Pod
 metadata:
   annotations:
     kubernetes.io/created-by: |
-      {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"explore-00","name":"parksmap-1","uid":"b5ae65e9-897e-11e6-bdaa-2cc2602f8794","apiVersion":"v1","resourceVersion":"6924"}}
+      {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"explore-user00","name":"parksmap-1","uid":"b5ae65e9-897e-11e6-bdaa-2cc2602f8794","apiVersion":"v1","resourceVersion":"6924"}}
     openshift.io/deployment-config.latest-version: "1"
     openshift.io/deployment-config.name: parksmap
     openshift.io/deployment.name: parksmap-1
@@ -185,7 +185,7 @@ environment. That's OK, as you will learn later.
 
 The way that a *Service* maps to a set of *Pods* is via a system of *Labels* and
 *Selectors*. *Services* are assigned an eternal IP address and many ports and
-protocols can be mapped. 
+protocols can be mapped.
 
 There is a lot more information about
 https://{{DOCS_URL}}/latest/architecture/core_concepts/pods_and_services.html#services[Services],
@@ -237,9 +237,9 @@ metadata:
   labels:
     app: parksmap
   name: parksmap
-  namespace: explore-00
+  namespace: explore-user00
   resourceVersion: "6893"
-  selfLink: /api/v1/namespaces/explore-00/services/parksmap
+  selfLink: /api/v1/namespaces/explore-user00/services/parksmap
   uid: b51260a9-897e-11e6-bdaa-2cc2602f8794
 spec:
   clusterIP: 172.30.169.213
@@ -312,7 +312,7 @@ You should see something like the following output:
 [source]
 ----
 Name:                   parksmap
-Namespace:              explore-00
+Namespace:              explore-user00
 Labels:                 app=parksmap
 Selector:               deploymentconfig=parksmap
 Type:                   ClusterIP

--- a/modules/explore.adoc
+++ b/modules/explore.adoc
@@ -81,7 +81,7 @@ During this lab, we are going to use a few different commands to make sure that
 things in the environment are working as expected.  Don't worry if you don't
 understand all of the terminology as we will cover it in detail in later labs.
 
-The first thing we want to do is switch to the *explore-userXX* project. You
+The first thing we want to do is switch to the *explore{{USER_SUFFIX}}XX* project. You
 can do this with the following command:
 
 [source]

--- a/modules/explore.adoc
+++ b/modules/explore.adoc
@@ -57,7 +57,7 @@ following confirmation message:
 ----
 Login successful.
 
-Using project "explore{{USER_SUFFIX}}".    
+Using project "explore{{USER_SUFFIX}}".
 ----
 
 Congratulations, you are now authenticated to the OpenShift server. The
@@ -81,7 +81,7 @@ During this lab, we are going to use a few different commands to make sure that
 things in the environment are working as expected.  Don't worry if you don't
 understand all of the terminology as we will cover it in detail in later labs.
 
-The first thing we want to do is switch to the *explore-XX* project. You
+The first thing we want to do is switch to the *explore-userXX* project. You
 can do this with the following command:
 
 [source]

--- a/modules/scaling.adoc
+++ b/modules/scaling.adoc
@@ -114,7 +114,7 @@ You will see something like the following output:
 [source]
 ----
 Name:			parksmap
-Namespace:		explore-user00
+Namespace:		explore{{USER_SUFFIX}}
 Labels:			app=parksmap
 Selector:		deploymentconfig=parksmap
 Type:			ClusterIP

--- a/modules/scaling.adoc
+++ b/modules/scaling.adoc
@@ -114,7 +114,7 @@ You will see something like the following output:
 [source]
 ----
 Name:			parksmap
-Namespace:		explore-00
+Namespace:		explore-user00
 Labels:			app=parksmap
 Selector:		deploymentconfig=parksmap
 Type:			ClusterIP


### PR DESCRIPTION
Running through the labs, I noticed, that there are some
inconsistencies within our naming convention meaning, that the ansible
script deploys projects with the name explore-user00…explore-userXX and
in some outputs we still write explore-XX